### PR TITLE
Wrap errors in SOAP `Fault` elements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries :: Python Modules'],
     packages=find_packages() + ['twisted.plugins'],
-    install_requires=['Twisted[tls] >= 15.0.0'])
+    install_requires=[
+        'Twisted[tls] >= 15.0.0',
+        'lxml>=3.6.0',
+    ])

--- a/soapproxy/proxy.py
+++ b/soapproxy/proxy.py
@@ -1,5 +1,5 @@
 from lxml.builder import ElementMaker, E
-from lxml.etree import tostring
+from lxml.etree import tostring, QName
 from OpenSSL import SSL
 from twisted.internet import reactor
 from twisted.internet.interfaces import IOpenSSLClientConnectionCreator
@@ -16,26 +16,8 @@ from twisted.web.server import NOT_DONE_YET
 from zope.interface import implementer
 
 
-
-SOAP_ENV = ElementMaker(
-    namespace='http://schemas.xmlsoap.org/soap/envelope/',
-    nsmap={'soapenv': 'http://schemas.xmlsoap.org/soap/envelope/'})
-
-
-
-def qnameid(ns, localpart):
-    """
-    Derive a QName identifier, as text, using an `ElementMaker` instance for
-    the namespace prefix and a local name.
-    """
-    if ns._namespace is None:
-        return localpart
-    needle = ns._namespace[1:-1]
-    for prefix, uri in ns._nsmap.items():
-        if uri == needle:
-            return u'{}:{}'.format(prefix, localpart)
-    else:
-        raise ValueError('Namespace missing', needle)
+SOAP_ENV_URI = 'http://schemas.xmlsoap.org/soap/envelope/'
+SOAP_ENV = ElementMaker(namespace=SOAP_ENV_URI, nsmap={'soapenv': SOAP_ENV_URI})
 
 
 
@@ -114,8 +96,10 @@ class ProxyResource(Resource):
         def writeError(f):
             request.setResponseCode(500)
             request.setHeader('content-type', 'application/xml')
+            faultcode = E.faultcode()
+            faultcode.text = QName(SOAP_ENV_URI, 'Server')
             fault = SOAP_ENV.Fault(
-                E.faultcode(qnameid(SOAP_ENV, 'Server')),
+                faultcode,
                 E.faultstring(f.getErrorMessage()),
                 E.faultactor(request.uri),
                 E.detail(


### PR DESCRIPTION
This should produce more comprehensible errors downstream, instead of (for example) Fusion choking on a raw Python traceback.

Fixes #3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fusionapp/soapproxy/5)
<!-- Reviewable:end -->
